### PR TITLE
#6 [Feat] Swagger 설정과 공통 응답 포맷(ApiResponse) 확인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/growthon/domain/produce/controller/ProduceController.java
+++ b/src/main/java/com/growthon/domain/produce/controller/ProduceController.java
@@ -1,0 +1,17 @@
+package com.growthon.domain.produce.controller;
+
+import com.growthon.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 테스트용 임시 컨트롤러 클래스
+@RestController
+public class ProduceController {
+
+    @GetMapping("/api/test")
+    public ResponseEntity<ApiResponse<String>> test() {
+        return ResponseEntity.ok(ApiResponse.of(200, "테스트 성공", "test"));
+    }
+
+}

--- a/src/main/java/com/growthon/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/growthon/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.growthon.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/growthon/global/config/SwaggerConfig.java
+++ b/src/main/java/com/growthon/global/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.growthon.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(new Info()
+                        .title("Spring Boot REST API Specifications")
+                        .description("API 명세서입니다.")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/com/growthon/global/domain/BaseEntity.java
+++ b/src/main/java/com/growthon/global/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.growthon.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+
+}

--- a/src/main/java/com/growthon/global/error/ErrorCode.java
+++ b/src/main/java/com/growthon/global/error/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.growthon.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorCode {
+
+    // 공통
+    INTERNAL_SERVER_ERROR("서버에 문제가 발생했습니다.", 500),
+    INVALID_INPUT("입력값이 유효하지 않습니다.", 400),
+
+    // 인증 & 권한
+    UNAUTHORIZED("로그인이 필요합니다.", 401),
+    FORBIDDEN("접근 권한이 없습니다.", 403),
+
+    // 비즈니스
+    NOT_FOUND_PRODUCE("해당 농산물을 찾을 수 없습니다.", 404);
+
+    private final String message;
+    private final int status;
+}

--- a/src/main/java/com/growthon/global/error/ErrorResponse.java
+++ b/src/main/java/com/growthon/global/error/ErrorResponse.java
@@ -1,0 +1,73 @@
+package com.growthon.global.error;
+
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final int status;
+    private final LocalDateTime timestamp;
+    private final List<FieldError> errors;
+
+    private ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+        this.status = errorCode.getStatus();
+        this.timestamp = LocalDateTime.now();
+        this.errors = new ArrayList<>();
+    }
+
+    private ErrorResponse(ErrorCode errorCode, List<FieldError> errors) {
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+        this.status = errorCode.getStatus();
+        this.timestamp = LocalDateTime.now();
+        this.errors = errors;
+    }
+
+    // 정적 팩토리 메서드: 단순 에러 응답
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
+
+    // 정적 팩토리 메서드: Validation 오류 응답
+    public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, FieldError.of(bindingResult));
+    }
+
+    /**
+     * 필드 유효성 에러 내부 클래스
+     */
+    @Getter
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+
+        private FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+            List<FieldError> errors = new ArrayList<>();
+            for (org.springframework.validation.FieldError error : fieldErrors) {
+                String rejectedValue = error.getRejectedValue() != null
+                        ? error.getRejectedValue().toString()
+                        : "";
+                errors.add(new FieldError(error.getField(), rejectedValue, error.getDefaultMessage()));
+            }
+            return errors;
+        }
+    }
+
+}

--- a/src/main/java/com/growthon/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/growthon/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.growthon.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import com.growthon.global.error.exception.BusinessException;
+
+import org.springframework.validation.BindException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 예상하지 못한 예외까지 포함하여 전부 잡아주는 최후의 보루 (NullPointerException, IndexOutOfBoundsException 등 개발 중 놓친 일반 런타임 예외)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        log.error("handleException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // @Valid, @NotBlank, @Email, @Pattern 등 DTO 필드 검증 실패 시 발생하는 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        log.error("handleMethodArgumentNotValidException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getBindingResult());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // @ModelAttribute나 폼 형식에서 타입 변환 실패, 바인딩 오류가 발생할 때 던져지는 예외 (Ex. 사용자가 "age=hello" 처럼 정수 자리에 문자를 보낼 경우)
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> handleBindException(BindException exception) {
+        log.error("handleBindException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT, exception.getBindingResult());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // 도메인 로직상에서 명시적으로 발생시키는 예외 (Ex. 접근 권한이 없습니다, 해당 농산물이 존재하지 않습니다 등)
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
+        log.error("handleBusinessException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(exception.getErrorCode().getStatus()));
+    }
+
+}

--- a/src/main/java/com/growthon/global/error/exception/BusinessException.java
+++ b/src/main/java/com/growthon/global/error/exception/BusinessException.java
@@ -1,0 +1,17 @@
+package com.growthon.global.error.exception;
+
+import com.growthon.global.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/growthon/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/growthon/global/error/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.growthon.global.error.exception;
+
+import com.growthon.global.error.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/growthon/global/response/ApiResponse.java
+++ b/src/main/java/com/growthon/global/response/ApiResponse.java
@@ -1,0 +1,30 @@
+package com.growthon.global.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    // API 명세 형식에 맞춰 구현한 공통 성공 응답 포맷
+
+    private final int status;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 상태 코드와 메시지를 직접 지정하는 경우 (Ex. return ApiResponse.of(201, "회원가입에 성공했습니다.", savedUserDto);)
+    public static <T> ApiResponse<T> of(int status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+
+    // 단순 조회 성공 (GET)
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(200, "요청이 성공적으로 처리되었습니다.", data);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=Farm2You
 spring.profiles.active = local
+springdoc.swagger-ui.display-request-duration = true


### PR DESCRIPTION
## 연관된 이슈
#6

## 작업 내용
- `/api/test` 엔드포인트에 대한 `ProduceController` 테스트 코드 작성  
- 공통 응답 포맷 `ApiResponse`의 JSON 구조(`status`, `message`, `data`)가 예상대로 반환되는지 테스트  

## 특이사항
- 컨트롤러 내부의 `/api/test` 관련 테스트용 로직은 확인해 보시고 지워도 될 것 같습니다.
