### PR TITLE
#26 [Feat] JWT 기반 로그인 후 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/growthon/global/config/SecurityConfig.java
+++ b/src/main/java/com/growthon/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.growthon.global.config;
 import com.growthon.global.jwt.JWTFilter;
 import com.growthon.global.jwt.JWTUtil;
 import com.growthon.global.jwt.LoginFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -53,6 +55,18 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+                .logout(logout -> logout
+                        .logoutUrl("/api/users/logout") // 로그아웃 요청 URL
+                        .logoutSuccessHandler((request, response, authentication) -> {
+                            // SecurityContext 초기화
+                            SecurityContextHolder.clearContext();
+
+                            // 성공 응답 반환 및 프론트 측에서 localStorage에 저장된 토큰 삭제
+                            response.setStatus(HttpServletResponse.SC_OK);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("{\"message\": \"로그아웃이 성공적으로 처리되었습니다.\"}");
+                        })
+                )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();

--- a/src/main/java/com/growthon/global/jwt/LoginFilter.java
+++ b/src/main/java/com/growthon/global/jwt/LoginFilter.java
@@ -65,7 +65,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = authorities.iterator().hasNext() ? authorities.iterator().next().getAuthority() : "ROLE_USER";
 
         // JWT 생성
-        String token = jwtUtil.createJwt(userDetails.getId(), email, role, 60 * 60 * 1000L); // 60분
+        String token = jwtUtil.createJwt(userDetails.getId(), email, role, 30 * 60 * 1000L); // 30분
 
         // 응답 데이터 구성
         Map<String, Object> responseData = Map.of(

--- a/src/main/java/com/growthon/global/jwt/LoginFilter.java
+++ b/src/main/java/com/growthon/global/jwt/LoginFilter.java
@@ -3,6 +3,7 @@ package com.growthon.global.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.growthon.global.error.ErrorCode;
 import com.growthon.global.error.ErrorResponse;
+import com.growthon.global.response.ApiResponse;
 import com.growthon.global.security.CustomUserDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -64,27 +65,29 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = authorities.iterator().hasNext() ? authorities.iterator().next().getAuthority() : "ROLE_USER";
 
         // JWT 생성
-        String token = jwtUtil.createJwt(userDetails.getId(), email, role, 60 * 60 * 1000L); // 60분 유효
+        String token = jwtUtil.createJwt(userDetails.getId(), email, role, 60 * 60 * 1000L); // 60분
 
-        // 응답 데이터 생성
+        // 응답 데이터 구성
         Map<String, Object> responseData = Map.of(
-                "status", 200,
-                "message", "로그인에 성공했습니다.",
-                "data", Map.of(
-                        "accessToken", token,
-                        "user", Map.of(
-                                "id", userDetails.getId(),
-                                "name", userDetails.getUsername(),
-                                "email", userDetails.getEmail(),
-                                "role", role
-                        )
+                "accessToken", token,
+                "user", Map.of(
+                        "id", userDetails.getId(),
+                        "name", userDetails.getUsername(),
+                        "email", userDetails.getEmail(),
+                        "role", role
                 )
         );
 
-        // JSON 응답 반환
+        // ApiResponse 사용
+        ApiResponse<Map<String, Object>> apiResponse = ApiResponse.of(
+                HttpServletResponse.SC_OK,
+                "로그인에 성공했습니다.",
+                responseData
+        );
+
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(responseData));
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }
 
     @Override
@@ -97,23 +100,16 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
 
         try {
-            // 필드 오류 생성
-            ErrorResponse.FieldError fieldError = new ErrorResponse.FieldError(
-                    "email or password",
-                    "",
-                    "Invalid email or password"
+            ApiResponse<String> apiResponse = ApiResponse.of(
+                    HttpServletResponse.SC_UNAUTHORIZED,
+                    "이메일 또는 비밀번호가 올바르지 않습니다.",
+                    null
             );
 
-            // ErrorResponse 생성
-            ErrorResponse errorResponse = new ErrorResponse(
-                    ErrorCode.INVALID_INPUT,
-                    List.of(fieldError)
-            );
-
-            // JSON 응답 반환
-            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+            response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
         } catch (IOException e) {
             log.error("Failed to write authentication error response", e);
         }
     }
+
 }


### PR DESCRIPTION
## 연관된 이슈
#26 

## 작업 내용
- 로그아웃 시 SecurityContext 초기화 (인증 정보를 제거하여 추가적인 농산물 등록, 수정, 삭제 불가 처리)
- 프론트엔드에서 localStorage에 저장된 JWT 토큰 삭제를 통해 로그아웃 처리
- JWT의 만료 시간을 짧게 설정하여 보안 강화

> 로그아웃 시 SecurityContextHolder.clearContext()를 호출하면, 이후 요청에서 더 이상 인증 정보에 접근할 수 없으므로 추가적인 작업(예: 농산물 등록, 수정, 삭제 등)이 불가능해집니다

## 특이사항
- JWT는 상태를 저장하지 않는 토큰이기 때문에, 서버는 클라이언트가 토큰을 삭제했는지 여부를 알 수 없음
- 현재는 JWT의 만료 시간을 짧게 설정하고, 프론트엔드에서 localStorage에 저장된 토큰을 삭제하는 방식으로 로그인 상태를 관리
- 보안 요구사항에 따라 추후 서버에서 토큰을 무효화(예: 블랙리스트 처리)하거나 리프레시 토큰을 도입하는 방안을 고려할 예정