### PR TITLE
#29 [Feat] ADMIN 권한 부족 시 ErrorCode 기반 에러 응답 처리

### DIFF
--- a/src/main/java/com/growthon/global/config/SecurityConfig.java
+++ b/src/main/java/com/growthon/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.growthon.global.config;
 import com.growthon.global.jwt.JWTFilter;
 import com.growthon.global.jwt.JWTUtil;
 import com.growthon.global.jwt.LoginFilter;
+import com.growthon.global.security.CustomAccessDeniedHandler;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -58,6 +59,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/produce/**").hasAuthority("ROLE_ADMIN")
                         .requestMatchers("/api/produce/**").authenticated()
                         .anyRequest().permitAll()
+                )
+                .exceptionHandling(exception -> exception
+                        .accessDeniedHandler(new CustomAccessDeniedHandler()) // AccessDeniedHandler 설정
                 )
                 .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/growthon/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/growthon/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.growthon.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.growthon.global.error.ErrorCode;
+import com.growthon.global.error.ErrorResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN);
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#29 

## 작업 내용
- `CustomAccessDeniedHandler` 클래스 구현
- Spring Security의 `SecurityConfig`에 `AccessDeniedHandler` 설정 추가
- ADMIN 권한 부족 시 `ErrorCode.FORBIDDEN`에 정의된 에러 응답 반환
- 권한 부족 시 에러 응답 반환 테스트 코드 작성
<img src="https://github.com/user-attachments/assets/da14c0c5-0a83-42fb-a784-c9c33285c782" width="700">

## 특이사항
> 없음
